### PR TITLE
Fixes wrong link to list of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A library of reusable, high-quality website sections to be used in your own Nuxt project - with and without Prismic.
 
-Make sure to view the complete list of components [here](https://prismic.io),
+Make sure to view the complete list of components [here](https://vue-essential-slices.netlify.app/?path=/story/*),
 or scroll down if want to contribute! 👇
 
 ⭐️Oh and star us on GitHub — it helps


### PR DESCRIPTION
# Description

**Which part of the repository is this PR related to?**
* Community (texts, guidelines...)

**Please include a summary of the feature, change or fix you provide.**
I hope the link is correct — it was what the website links to under *Browse Components*.

# How Has This Been Tested?

I read it a couple of times. 😉 

# Checklist

Please describe the advancement of your pull request:

- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings (including linting warnings and errors)
